### PR TITLE
Add support for functions which take arguments as references

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,8 @@ features = ["nightly"]
 version = "0.15"
 features = ["full"]
 
+[dev-dependencies]
+lru-cache = "0.1.1"
+
 [lib]
 proc-macro = true

--- a/tests/args_as_ref.rs
+++ b/tests/args_as_ref.rs
@@ -1,0 +1,17 @@
+#[test]
+fn args_as_ref() {
+    use lru_cache_macros::lru_cache;
+
+    #[lru_cache(20)]
+    fn fib(x: &u32) -> u64 {
+        println!("{:?}", x);
+        if *x <= 1 {
+            1
+        } else {
+            fib(&(x - 1)) + fib(&(x - 2))
+        }
+    }
+
+    assert_eq!(fib(&19), 6765);
+}
+


### PR DESCRIPTION
This PR adds support for cacheing functions which take arguments as reference. It also cleans up the doc tests and adds `lru-cache` as a dev-dependency to ensure the doc tests work as expected. 