### PR TITLE
Implemented cross thread cache

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "A procedural macro for automatically caching the output of functi
 
 [dependencies]
 quote = "0.6"
+lazy_static = "1.2.0"
 
 [dependencies.proc-macro2]
 version = "0.4"

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,19 +1,38 @@
 use lru_cache_macros::lru_cache;
+use std::thread;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[test]
 fn ignore_args() {
     #[lru_cache(20)]
     #[lru_config(ignore_args = call_count)]
-    fn fib(x: u32, call_count: &mut u32) -> u64 {
-        *call_count += 1;
+    fn fib(x: u32) -> u64 {
+        CALL_COUNT.fetch_add(1, Ordering::SeqCst);
         if x <= 1 {
             1
         } else {
-            fib(x - 1, call_count) + fib(x - 2, call_count)
+            fib(x - 1) + fib(x - 2)
         }
     }
 
-    let mut call_count = 0;
-    assert_eq!(fib(39, &mut call_count), 102_334_155);
-    assert_eq!(call_count, 40);
+    let t1 = thread::spawn( || {
+        assert_eq!(fib(39), 102_334_155);
+    });
+
+    let t2 = thread::spawn( || {
+        assert_eq!(fib(39), 102_334_155);
+    });
+
+    let t3 = thread::spawn( || {
+        assert_eq!(fib(39), 102_334_155);
+    });
+
+    t1.join().unwrap();
+    t2.join().unwrap();
+    t3.join().unwrap();
+
+    // threads should share a cache, so total runs should be less than 40 * 3
+    assert!(CALL_COUNT.load(Ordering::SeqCst) < 120);
 }


### PR DESCRIPTION
This PR allows a cache to be shared across threads. It also removes the use of UnsafeCell and one unsafe block.

Potential downsides:
 - requires lazy_static (I'm pretty sure it can be modified to remove this requirement, by using `Mutex::new(Option<#cache_type::new(#cache_size)>)`
 - overhead of Mutex may be worse than not sharing the cache for certain workloads

As a side note, it looks like right now all the caches are just named `cache`. Won't this cause a name conflict if multiple functions are configured to be cached? Or does thread_local somehow handle this? 