### PR TITLE
initial changes to support expiring map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ features = ["full", "extra-traits"]
 
 [dev-dependencies]
 lru-cache = "0.1.1"
+expiring_map = "0.1.0"
 
 [lib]
 proc-macro = true

--- a/tests/args_as_ref.rs
+++ b/tests/args_as_ref.rs
@@ -1,8 +1,9 @@
+use lru_cache_macros::lru_cache as cache;
+use lru_cache::LruCache;
+
 #[test]
 fn args_as_ref() {
-    use lru_cache_macros::lru_cache;
-
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     fn fib(x: &u32) -> u64 {
         println!("{:?}", x);
         if *x <= 1 {

--- a/tests/cache_type.rs
+++ b/tests/cache_type.rs
@@ -1,0 +1,16 @@
+use lru_cache_macros::lru_cache;
+use std::time::Duration;
+use expiring_map::ExpiringMap;
+
+#[test]
+fn cache_type() {
+    use std::f64;
+
+    #[lru_cache(Duration::from_secs(60))]
+    #[lru_config(cache_type = ExpiringMap)]
+    fn cached_sqrt(x: u64) -> f64 {
+        f64::sqrt(x as f64)
+    }
+
+    assert_eq!(cached_sqrt(9), f64::sqrt(9.0));
+}

--- a/tests/cache_type.rs
+++ b/tests/cache_type.rs
@@ -1,13 +1,34 @@
-use lru_cache_macros::lru_cache;
+use lru_cache_macros::lru_cache as cache;
 use std::time::Duration;
 use expiring_map::ExpiringMap;
+use std::hash::Hash;
 
 #[test]
 fn cache_type() {
     use std::f64;
 
-    #[lru_cache(Duration::from_secs(60))]
-    #[lru_config(cache_type = ExpiringMap)]
+    #[cache(ExpiringMap : ExpiringMap::new(Duration::from_secs(60)))]
+    fn cached_sqrt(x: u64) -> f64 {
+        f64::sqrt(x as f64)
+    }
+
+    assert_eq!(cached_sqrt(9), f64::sqrt(9.0));
+}
+
+fn custom_create_cache_method<K, V>(duration: Duration, _extra_arg: u32) -> ExpiringMap<K, V>
+    where K: Eq + Hash
+{
+    ExpiringMap::new(duration)
+}
+
+#[test]
+fn non_standard_cache_creation() {
+    // this tests support for caches which do not use a `new` method,
+    //      and/or whose creation function uses more than 1 argument
+
+    use std::f64;
+
+    #[cache(ExpiringMap : custom_create_cache_method(Duration::from_secs(60), 1))]
     fn cached_sqrt(x: u64) -> f64 {
         f64::sqrt(x as f64)
     }

--- a/tests/clone_only_type.rs
+++ b/tests/clone_only_type.rs
@@ -1,4 +1,5 @@
-use lru_cache_macros::lru_cache;
+use lru_cache_macros::lru_cache as cache;
+use lru_cache::LruCache;
 
 use std::ops;
 
@@ -21,7 +22,7 @@ impl ops::Sub for NoCopyI32 {
 
 #[test]
 fn clone_only_type() {
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     fn fib(x: NoCopyI32) -> NoCopyI32 {
         if x <= NoCopyI32(1) {
             NoCopyI32(1)

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,6 +1,7 @@
 use lru_cache_macros::lru_cache;
 use std::thread;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time;
 
 #[test]
 fn thread_local_ignore_args() {
@@ -39,18 +40,16 @@ fn multithreaded() {
         assert_eq!(fib(39), 102_334_155);
     });
 
-    let t2 = thread::spawn( || {
-        assert_eq!(fib(39), 102_334_155);
-    });
+    let ten_millis = time::Duration::from_millis(10);
+    thread::sleep(ten_millis);
 
-    let t3 = thread::spawn( || {
+    let t2 = thread::spawn( || {
         assert_eq!(fib(39), 102_334_155);
     });
 
     t1.join().unwrap();
     t2.join().unwrap();
-    t3.join().unwrap();
 
-    // threads should share a cache, so total runs should be less than 40 * 3
-    assert!(CALL_COUNT.load(Ordering::SeqCst) < 120);
+    // threads should share a cache, so total runs should be less than 40 * 2
+    assert!(CALL_COUNT.load(Ordering::SeqCst) < 80);
 }

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,11 +1,13 @@
-use lru_cache_macros::lru_cache;
+use lru_cache_macros::lru_cache as cache;
+use lru_cache::LruCache;
+
 use std::thread;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time;
 
 #[test]
 fn thread_local_ignore_args() {
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     #[lru_config(ignore_args = call_count)]
     #[lru_config(thread_local)]
     fn fib(x: u32, call_count: &mut u32) -> u64 {
@@ -26,7 +28,7 @@ fn thread_local_ignore_args() {
 fn multithreaded() {
     static CALL_COUNT: AtomicUsize = AtomicUsize::new(0);
 
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     fn fib(x: u32) -> u64 {
         CALL_COUNT.fetch_add(1, Ordering::SeqCst);
         if x <= 1 {

--- a/tests/multiple_args.rs
+++ b/tests/multiple_args.rs
@@ -1,8 +1,9 @@
+use lru_cache_macros::lru_cache as cache;
+use lru_cache::LruCache;
+
 #[test]
 fn multiple_args() {
-    use lru_cache_macros::lru_cache;
-
-    #[lru_cache(200)]
+    #[cache(LruCache : LruCache::new(20))]
     #[inline]
     fn ackermann(m: u64, n: u64) -> u64 {
         if m == 0 {

--- a/tests/multiple_caches.rs
+++ b/tests/multiple_caches.rs
@@ -1,13 +1,14 @@
-use lru_cache_macros::lru_cache;
+use lru_cache_macros::lru_cache as cache;
+use lru_cache::LruCache;
 
 #[test]
 fn multiple_caches() {
     use std::f64;
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     fn cached_sqrt(x: u64) -> f64 {
         f64::sqrt(x as f64)
     }
-    #[lru_cache(20)]
+    #[cache(LruCache : LruCache::new(20))]
     fn cached_log(x: u64) -> f64 {
         f64::ln(x as f64)
     }


### PR DESCRIPTION
implements #6 

This is an initial implementation of support for map types whose `new` function takes something other than a number. For now, this just takes any expression and passes it along to the new method, which has the downside of reducing the clarity of error messages. It also doesn't support `new` methods which take multiple arguments. And it maintains the requirement that the map be construct-able with a method called `new`. 

Overall, I believe for this feature to be built correctly, it probably requires a redesign to the way users will use this macro. I just wanted to put this PR out there to start the conversation. 